### PR TITLE
Implement multi-page Next.js site

### DIFF
--- a/human-web/app/about/page.tsx
+++ b/human-web/app/about/page.tsx
@@ -1,0 +1,15 @@
+import Header from '../partial/header';
+import AboutUs from '../partial/about-us';
+import OurTeam from '../partial/our-team';
+import Footer from '../partial/footer';
+
+export default function AboutPage() {
+  return (
+    <div>
+      <Header />
+      <AboutUs />
+      <OurTeam />
+      <Footer />
+    </div>
+  );
+}

--- a/human-web/app/companies/page.tsx
+++ b/human-web/app/companies/page.tsx
@@ -1,0 +1,13 @@
+import Header from '../partial/header';
+import Companies from '../partial/companies';
+import Footer from '../partial/footer';
+
+export default function CompaniesPage() {
+  return (
+    <div>
+      <Header />
+      <Companies />
+      <Footer />
+    </div>
+  );
+}

--- a/human-web/app/contact/page.tsx
+++ b/human-web/app/contact/page.tsx
@@ -1,0 +1,13 @@
+import Header from '../partial/header';
+import ContactUs from '../partial/contact-us';
+import Footer from '../partial/footer';
+
+export default function ContactPage() {
+  return (
+    <div>
+      <Header />
+      <ContactUs />
+      <Footer />
+    </div>
+  );
+}

--- a/human-web/app/faq/page.tsx
+++ b/human-web/app/faq/page.tsx
@@ -1,0 +1,13 @@
+import Header from '../partial/header';
+import FAQ from '../partial/faq';
+import Footer from '../partial/footer';
+
+export default function FAQPage() {
+  return (
+    <div>
+      <Header />
+      <FAQ />
+      <Footer />
+    </div>
+  );
+}

--- a/human-web/app/methodology/page.tsx
+++ b/human-web/app/methodology/page.tsx
@@ -1,0 +1,13 @@
+import Header from '../partial/header';
+import Methodology from '../partial/methodology';
+import Footer from '../partial/footer';
+
+export default function MethodologyPage() {
+  return (
+    <div>
+      <Header />
+      <Methodology />
+      <Footer />
+    </div>
+  );
+}

--- a/human-web/app/partial/companies.tsx
+++ b/human-web/app/partial/companies.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const Companies: React.FC = () => {
+  return (
+    <section className="companies">
+      <div className="companies__container">
+        <h2 className="companies__title">Empresas</h2>
+        <p className="companies__description">Propuesta de valor para empresas</p>
+        <ul className="companies__list">
+          <li>Cursos personalizados</li>
+          <li>Espacios cardioprotegidos</li>
+          <li>Contacto directo</li>
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default Companies;

--- a/human-web/app/partial/faq.tsx
+++ b/human-web/app/partial/faq.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const questions = [
+  {
+    q: '¿Necesito conocimientos previos?',
+    a: 'No, nuestros cursos están diseñados para todo público.',
+  },
+  {
+    q: '¿Dan certificado?',
+    a: 'Sí, obtendrás una certificación al completar el curso.',
+  },
+  {
+    q: '¿Puedo hacer el curso si soy empresa?',
+    a: 'Claro, contamos con programas especiales para empresas.',
+  },
+];
+
+const FAQ: React.FC = () => {
+  return (
+    <section className="faq">
+      <div className="faq__container">
+        <h2 className="faq__title">Preguntas Frecuentes</h2>
+        {questions.map((item, index) => (
+          <div className="faq__item" key={index}>
+            <h3 className="faq__question">{item.q}</h3>
+            <p className="faq__answer">{item.a}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default FAQ;

--- a/human-web/app/partial/header.tsx
+++ b/human-web/app/partial/header.tsx
@@ -33,9 +33,11 @@ const Header: React.FC = () => {
         </button>
         <nav className={`header__nav ${isMenuOpen ? 'header__nav--open' : ''}`}>
           <ul>
-            <li>Quienes somos?</li>
-            <li>Nuestros Servicios</li>
-            <li>Contactanos</li>
+            <li><Link href="/about">Quienes Somos</Link></li>
+            <li><Link href="/methodology">Metodología</Link></li>
+            <li><Link href="/trainings">Capacitaciones</Link></li>
+            <li><Link href="/companies">Empresas</Link></li>
+            <li><Link href="/contact">Contacto</Link></li>
           </ul>
         </nav>
         <nav className={`header__social-nav`}>

--- a/human-web/app/partial/methodology.tsx
+++ b/human-web/app/partial/methodology.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const Methodology: React.FC = () => {
+  return (
+    <section className="methodology">
+      <div className="methodology__container">
+        <h2 className="methodology__title">Metodología</h2>
+        <p className="methodology__description">
+          Descripción del enfoque práctico, entrenamientos continuos y simulaciones.
+        </p>
+        <ul className="methodology__list">
+          <li>Personalización según rubro (empresas, instituciones, etc.)</li>
+          <li>Modalidades de cursado: presencial, online, híbrido</li>
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default Methodology;

--- a/human-web/app/partial/testimonials.tsx
+++ b/human-web/app/partial/testimonials.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+const testimonials = [
+  {
+    name: 'Ana P.',
+    text: 'El curso superó mis expectativas y ahora me siento preparada para actuar en emergencias.',
+  },
+  {
+    name: 'Empresa XYZ',
+    text: 'La capacitación fue muy completa y adaptada a nuestras necesidades.',
+  },
+  {
+    name: 'Carlos G.',
+    text: 'Excelente metodología y profesionales comprometidos.',
+  },
+];
+
+const Testimonials: React.FC = () => {
+  return (
+    <section className="testimonials">
+      <div className="testimonials__container">
+        <h2 className="testimonials__title">Testimonios</h2>
+        <div className="testimonials__items">
+          {testimonials.map((t, index) => (
+            <div className="testimonials__item" key={index}>
+              <p className="testimonials__text">"{t.text}"</p>
+              <p className="testimonials__name">- {t.name}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Testimonials;

--- a/human-web/app/partial/trainings.tsx
+++ b/human-web/app/partial/trainings.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+const trainings = [
+  {
+    title: 'Primeros Auxilios y RCP',
+    items: ['Público general', 'Empresas', 'Liceos / instituciones', 'Entrenamientos recurrentes'],
+  },
+  {
+    title: 'Apoyo Emocional en Emergencias',
+    items: ['Versión adultos', 'Versión pediátrica'],
+  },
+  {
+    title: 'Urgencias Acuáticas',
+    items: ['Curso de Primera Respuesta Acuática', 'Entrenamientos personalizados', 'Menciones a ESBRA Argentina'],
+  },
+  {
+    title: 'Programa Birdie (Natación)',
+    items: ['Entrenamientos personalizados', 'Preparación para pruebas y competencias'],
+  },
+];
+
+const Trainings: React.FC = () => {
+  return (
+    <section className="trainings">
+      <div className="trainings__container">
+        <h2 className="trainings__title">Capacitaciones</h2>
+        <div className="trainings__blocks">
+          {trainings.map((training, index) => (
+            <div className="trainings__block" key={index}>
+              <h3 className="trainings__block-title">{training.title}</h3>
+              <ul>
+                {training.items.map((item, idx) => (
+                  <li key={idx}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Trainings;

--- a/human-web/app/styles/globals.scss
+++ b/human-web/app/styles/globals.scss
@@ -25,3 +25,8 @@ body {
 @import './partial/contact-us.scss';
 @import './partial/footer.scss';
 @import './partial/our-team.scss';
+@import './partial/methodology.scss';
+@import './partial/trainings.scss';
+@import './partial/companies.scss';
+@import './partial/faq.scss';
+@import './partial/testimonials.scss';

--- a/human-web/app/styles/partial/companies.scss
+++ b/human-web/app/styles/partial/companies.scss
@@ -1,0 +1,24 @@
+.companies {
+  padding: $spacing-xl $spacing-lg;
+  background-color: $color-neutral;
+
+  &__container {
+    max-width: $content-width;
+    margin: 0 auto;
+    color: $color-primary;
+  }
+
+  &__title {
+    font-size: $font-size-xl;
+    margin-bottom: $spacing-md;
+  }
+
+  &__list {
+    list-style: disc;
+    padding-left: $spacing-lg;
+
+    li {
+      margin-bottom: $spacing-sm;
+    }
+  }
+}

--- a/human-web/app/styles/partial/faq.scss
+++ b/human-web/app/styles/partial/faq.scss
@@ -1,0 +1,23 @@
+.faq {
+  padding: $spacing-xl $spacing-lg;
+  background-color: $color-white;
+  color: $color-primary;
+
+  &__container {
+    max-width: $content-width;
+    margin: 0 auto;
+  }
+
+  &__title {
+    font-size: $font-size-xl;
+    margin-bottom: $spacing-lg;
+  }
+
+  &__item {
+    margin-bottom: $spacing-md;
+  }
+
+  &__question {
+    font-weight: bold;
+  }
+}

--- a/human-web/app/styles/partial/methodology.scss
+++ b/human-web/app/styles/partial/methodology.scss
@@ -1,0 +1,28 @@
+.methodology {
+  padding: $spacing-xl $spacing-lg;
+  background-color: $color-neutral;
+
+  &__container {
+    max-width: $content-width;
+    margin: 0 auto;
+    color: $color-primary;
+  }
+
+  &__title {
+    font-size: $font-size-xl;
+    margin-bottom: $spacing-md;
+  }
+
+  &__description {
+    margin-bottom: $spacing-md;
+  }
+
+  &__list {
+    list-style: disc;
+    padding-left: $spacing-lg;
+
+    li {
+      margin-bottom: $spacing-sm;
+    }
+  }
+}

--- a/human-web/app/styles/partial/testimonials.scss
+++ b/human-web/app/styles/partial/testimonials.scss
@@ -1,0 +1,32 @@
+.testimonials {
+  padding: $spacing-xl $spacing-lg;
+  background-color: $color-neutral;
+  color: $color-primary;
+
+  &__container {
+    max-width: $content-width;
+    margin: 0 auto;
+  }
+
+  &__title {
+    font-size: $font-size-xl;
+    margin-bottom: $spacing-lg;
+  }
+
+  &__items {
+    display: grid;
+    gap: $spacing-md;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  }
+
+  &__item {
+    background-color: $color-white;
+    border-radius: $border-radius-md;
+    padding: $spacing-md;
+  }
+
+  &__text {
+    font-style: italic;
+    margin-bottom: $spacing-sm;
+  }
+}

--- a/human-web/app/styles/partial/trainings.scss
+++ b/human-web/app/styles/partial/trainings.scss
@@ -1,0 +1,42 @@
+.trainings {
+  padding: $spacing-xl $spacing-lg;
+  background-color: $color-white;
+
+  &__container {
+    max-width: $content-width;
+    margin: 0 auto;
+  }
+
+  &__title {
+    color: $color-primary;
+    font-size: $font-size-xl;
+    margin-bottom: $spacing-lg;
+  }
+
+  &__blocks {
+    display: grid;
+    gap: $spacing-lg;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  }
+
+  &__block {
+    background-color: $color-neutral;
+    border-radius: $border-radius-md;
+    padding: $spacing-lg;
+
+    &-title {
+      font-size: $font-size-lg;
+      color: $color-primary;
+      margin-bottom: $spacing-sm;
+    }
+
+    ul {
+      padding-left: $spacing-lg;
+      list-style: disc;
+
+      li {
+        margin-bottom: $spacing-xs;
+      }
+    }
+  }
+}

--- a/human-web/app/styles/variables.scss
+++ b/human-web/app/styles/variables.scss
@@ -2,6 +2,9 @@ $content-width: 1200px;
 // Colors
 $color-primary: #00214d;
 $color-secondary: #1e98a8;
+$color-secondary-accent: #629941;
+$color-neutral: #d9d9d9;
+$color-light-neutral: #ffffff;
 $color-white: #ffffff;
 $color-gray: #bfc0c2;
 $color-dark-gray: #4a4a4a; 

--- a/human-web/app/testimonials/page.tsx
+++ b/human-web/app/testimonials/page.tsx
@@ -1,0 +1,13 @@
+import Header from '../partial/header';
+import Testimonials from '../partial/testimonials';
+import Footer from '../partial/footer';
+
+export default function TestimonialsPage() {
+  return (
+    <div>
+      <Header />
+      <Testimonials />
+      <Footer />
+    </div>
+  );
+}

--- a/human-web/app/trainings/page.tsx
+++ b/human-web/app/trainings/page.tsx
@@ -1,0 +1,13 @@
+import Header from '../partial/header';
+import Trainings from '../partial/trainings';
+import Footer from '../partial/footer';
+
+export default function TrainingsPage() {
+  return (
+    <div>
+      <Header />
+      <Trainings />
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add color palette variables
- include navigation links to new pages
- create pages: About, Methodology, Trainings, Companies, Contact, FAQ and Testimonials
- provide partial components for methodology, trainings, companies, faq and testimonials
- add SCSS styling for new components

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68405481467c8331b6ad5a1d7e06399c